### PR TITLE
Precompute per-location class masks for stop modes

### DIFF
--- a/include/motis/adr_extend_tt.h
+++ b/include/motis/adr_extend_tt.h
@@ -18,6 +18,8 @@ using tz_map_t = vector_map<adr_extra_place_idx_t, date::time_zone const*>;
 
 struct adr_ext {
   vector_map<nigiri::location_idx_t, adr_extra_place_idx_t> location_place_;
+  vector_map<nigiri::location_idx_t, nigiri::routing::clasz_mask_t>
+      location_clasz_;
   vector_map<adr_extra_place_idx_t, nigiri::routing::clasz_mask_t> place_clasz_;
   vector_map<adr_extra_place_idx_t, float> place_importance_;
 };

--- a/src/adr_extend_tt.cc
+++ b/src/adr_extend_tt.cc
@@ -5,6 +5,7 @@
 #include "nigiri/special_stations.h"
 
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -304,20 +305,24 @@ adr_ext adr_extend_tt(nigiri::timetable const& tt,
   // Compute importance = transport count weighted by clasz.
   ret.place_importance_.resize(place_location.size());
   ret.place_clasz_.resize(place_location.size());
+  ret.location_clasz_.resize(tt.n_locations());
   {
     auto const event_counts = utl::scoped_timer{"guesser event_counts"};
     for (auto i = n::kNSpecialStations; i != tt.n_locations(); ++i) {
       auto const l = n::location_idx_t{i};
 
+      auto mask = n::routing::clasz_mask_t{0U};
       auto transport_counts = std::array<unsigned, n::kNumClasses>{};
       for (auto const& r : tt.location_routes_[l]) {
         auto const clasz =
             static_cast<std::underlying_type_t<n::clasz>>(tt.route_clasz_[r]);
+        mask |= (1U << clasz);
         for (auto const tr : tt.route_transport_ranges_[r]) {
           transport_counts[clasz] +=
               tt.bitfields_[tt.transport_traffic_days_[tr]].count();
         }
       }
+      ret.location_clasz_[l] = mask;
 
       constexpr auto const prio =
           std::array<float, kClaszMax>{/* Air */ 20,

--- a/src/place.cc
+++ b/src/place.cc
@@ -132,38 +132,45 @@ api::Place to_place(n::timetable const* tt,
                 return p.empty() ? std::nullopt : std::optional{std::string{p}};
               };
 
-              auto const pos = tt->locations_.coordinates_[l];
-              auto const p = tt->locations_.get_root_idx(l);
-              auto const timezone = get_tz(*tt, ae, tz_map, p);
+            auto const pos = tt->locations_.coordinates_[l];
+            auto const p = tt->locations_.get_root_idx(l);
+            auto const timezone = get_tz(*tt, ae, tz_map, p);
+            auto const modes = [&]() {
+              if (ae == nullptr || ae->location_clasz_.empty()) {
+                return std::optional<std::vector<api::ModeEnum>>{};
+              }
+              auto const mask = ae->location_clasz_.at(l);
+              if (mask == 0U) {
+                return std::optional<std::vector<api::ModeEnum>>{};
+              }
+              return std::optional<std::vector<api::ModeEnum>>{
+                  to_modes(mask, 5)};
+            }();
 
-              return {
-                  .name_ = std::string{tt->translate(
-                      lang, tt->locations_.names_.at(p))},
-                  .stopId_ = tags->id(*tt, l),
-                  .parentId_ = p == n::location_idx_t::invalid()
-                                   ? std::nullopt
-                                   : std::optional{tags->id(*tt, p)},
-                  .importance_ = ae == nullptr
-                                     ? std::nullopt
-                                     : std::optional{ae->place_importance_.at(
-                                           ae->location_place_.at(l))},
-                  .lat_ = pos.lat_,
-                  .lon_ = pos.lng_,
-                  .level_ = get_level(w, pl, matches, l),
-                  .tz_ = timezone == nullptr ? fallback_tz
-                                             : std::optional{timezone->name()},
-                  .scheduledTrack_ = get_track(tt_l.scheduled_),
-                  .track_ = get_track(tt_l.l_),
-                  .description_ = get_description(tt_l.scheduled_),
-                  .vertexType_ = api::VertexTypeEnum::TRANSIT,
-                  .modes_ =
-                      ae != nullptr
-                          ? std::optional<std::vector<api::ModeEnum>>{to_modes(
-                                ae->place_clasz_.at(ae->location_place_.at(p)),
-                                5)}
-                          : std::nullopt};
-            }
-          }},
+            return {
+                .name_ = std::string{tt->translate(
+                    lang, tt->locations_.names_.at(p))},
+                .stopId_ = tags->id(*tt, l),
+                .parentId_ = p == n::location_idx_t::invalid()
+                                 ? std::nullopt
+                                 : std::optional{tags->id(*tt, p)},
+                .importance_ =
+                    ae == nullptr
+                        ? std::nullopt
+                        : std::optional{ae->place_importance_.at(
+                              ae->location_place_.at(l))},
+                .lat_ = pos.lat_,
+                .lon_ = pos.lng_,
+                .level_ = get_level(w, pl, matches, l),
+                .tz_ = timezone == nullptr ? fallback_tz
+                                           : std::optional{timezone->name()},
+                .scheduledTrack_ = get_track(tt_l.scheduled_),
+                .track_ = get_track(tt_l.l_),
+                .description_ = get_description(tt_l.scheduled_),
+                .vertexType_ = api::VertexTypeEnum::TRANSIT,
+                .modes_ = std::move(modes)};
+          }
+        }},
       l);
 }
 


### PR DESCRIPTION
### Motivation
- Stop mode lists were previously derived from parent/place aggregates or recomputed per-request, causing incorrect modes for some stops and extra modes for platform points.
- Precomputing per-location class masks avoids repeated iteration over routes when emitting places and ensures stop-specific mode accuracy.
- This change improves correctness (exact stop modes like trolley are preserved) and reduces runtime work at request time.

### Description
- Added `location_clasz_` to `adr_ext` in `include/motis/adr_extend_tt.h` to store per-location class masks.
- While extending the timetable in `src/adr_extend_tt.cc`, compute and store a `nigiri::routing::clasz_mask_t` per location by scanning `tt.location_routes_` and `tt.route_clasz_`, and resized the new vector accordingly.
- Updated `src/place.cc` to use the precomputed `ae->location_clasz_.at(l)` when building `.modes_` for places instead of scanning routes or using the parent/place mask, and refactored the local modes construction.
- Added a missing `#include <type_traits>` required for masking operations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698904585188832a82c5a2045c8a62bc)