### PR TITLE
ci: publish OpenAPI schema for Transit sync

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -129,6 +129,26 @@ jobs:
             ghcr.io/piotrski/motis:${{ github.ref_name }}
             ghcr.io/piotrski/motis:${{ github.sha }}
 
+      - name: Publish OpenAPI schema release asset
+        id: schema-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: motis-contract-${{ github.sha }}
+          SCHEMA_URL: https://github.com/piotrski/motis/releases/download/motis-contract-${{ github.sha }}/openapi.yaml
+        run: |
+          if ! gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release create "${RELEASE_TAG}" \
+              --target "${{ github.sha }}" \
+              --title "MOTIS contract ${{ github.sha }}" \
+              --notes "OpenAPI schema for MOTIS image ghcr.io/piotrski/motis:${{ github.sha }}" \
+              --latest=false
+          fi
+
+          gh release upload "${RELEASE_TAG}" openapi.yaml#openapi.yaml --clobber
+
+          echo "release_tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "schema_url=${SCHEMA_URL}" >> "${GITHUB_OUTPUT}"
+
       - name: Notify Transit contract sync
         env:
           GH_TOKEN: ${{ secrets.TRANSIT_CONTRACT_SYNC_TOKEN }}
@@ -142,6 +162,8 @@ jobs:
             --method POST \
             repos/piotrski/transit/dispatches \
             -f event_type=motis-contract-published \
+            -F "client_payload[schema_url]=${{ steps.schema-release.outputs.schema_url }}" \
+            -F "client_payload[motis_release_tag]=${{ steps.schema-release.outputs.release_tag }}" \
             -F "client_payload[motis_run_id]=${{ github.run_id }}" \
             -F "client_payload[motis_artifact_name]=openapi-yaml" \
             -F "client_payload[motis_ref]=${{ github.ref_name }}" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,6 +88,12 @@ jobs:
           name: motis-linux-amd64
           path: motis-linux-amd64/motis-linux-amd64.tar.bz2
 
+      - name: Upload OpenAPI schema
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-yaml
+          path: openapi.yaml
+
   docker:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -122,3 +128,22 @@ jobs:
           tags: |
             ghcr.io/piotrski/motis:${{ github.ref_name }}
             ghcr.io/piotrski/motis:${{ github.sha }}
+
+      - name: Notify Transit contract sync
+        env:
+          GH_TOKEN: ${{ secrets.TRANSIT_CONTRACT_SYNC_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "TRANSIT_CONTRACT_SYNC_TOKEN is not configured; skipping Transit contract sync dispatch."
+            exit 0
+          fi
+
+          gh api \
+            --method POST \
+            repos/piotrski/transit/dispatches \
+            -f event_type=motis-contract-published \
+            -F "client_payload[motis_run_id]=${{ github.run_id }}" \
+            -F "client_payload[motis_artifact_name]=openapi-yaml" \
+            -F "client_payload[motis_ref]=${{ github.ref_name }}" \
+            -F "client_payload[motis_sha]=${{ github.sha }}" \
+            -F "client_payload[motis_image]=ghcr.io/piotrski/motis:${{ github.sha }}"


### PR DESCRIPTION
Publishes the MOTIS OpenAPI schema as part of the patches build pipeline.\n\nChanges:\n- Uploads openapi.yaml as an Actions artifact for fallback/manual consumption.\n- Publishes openapi.yaml as a durable GitHub Release asset tagged motis-contract-<sha>.\n- Dispatches piotrski/transit with the schema URL and MOTIS image/ref metadata after the image push succeeds.\n\nSetup:\n- TRANSIT_CONTRACT_SYNC_TOKEN is configured in the MOTIS repository secrets.\n\nValidation:\n- YAML parse check for docker.yml\n- git diff --check